### PR TITLE
Cancel crafting

### DIFF
--- a/Lua Files/control.lua
+++ b/Lua Files/control.lua
@@ -312,6 +312,28 @@ local function craft()
 	end
 end
 
+-- Cancels a handcraft a recipe
+local function cancel_crafting()
+	local queue = player.crafting_queue
+
+	for i = 1, #queue do
+		if queue[i].recipe == item then
+			if count == -1 then
+				player.cancel_crafting{index = i}
+				return true
+			elseif queue[i].count >= count then
+				player.cancel_crafting{index = i, count = count}
+				return true
+			else
+				warning(string.format("Step: %s, Action: %s, Step: %d - Cancel craft: It is not possible to cancel %s - Please check the script", task[1], task[2], step, item:gsub("-", " "):gsub("^%l", string.upper)))
+				return false
+			end
+		end
+	end
+	warning(string.format("Step: %s, Action: %s, Step: %d - Cancel craft: It is not possible to cancel %s - Please check the script", task[1], task[2], step, item:gsub("-", " "):gsub("^%l", string.upper)))
+	return false
+end
+
 local function item_is_tile(item)
 	if item == "stone-brick"
 	or item == "concrete"
@@ -908,6 +930,14 @@ local function doStep(current_step)
 		item = current_step[4]
 
 		return craft()
+
+	elseif current_step[2] == "cancel crafting" then
+        task_category = "Cancel craft"
+        task = current_step[1]
+		count = current_step[3]
+		item = current_step[4]
+
+		return cancel_crafting()
 
 	elseif current_step[2] == "build" then
         task_category = "Build"

--- a/src/GUI/GUI.fbp
+++ b/src/GUI/GUI.fbp
@@ -555,8 +555,22 @@
                         <property name="unchecked_bitmap"></property>
                         <event name="OnMenuSelection">OnMoveDownMenuSelected</event>
                     </object>
+                    <object class="wxMenuItem" expanded="1">
+                        <property name="bitmap"></property>
+                        <property name="checked">0</property>
+                        <property name="enabled">1</property>
+                        <property name="help"></property>
+                        <property name="id">wxID_ANY</property>
+                        <property name="kind">wxITEM_NORMAL</property>
+                        <property name="label">Cancel Crafting</property>
+                        <property name="name">shortcut_cancel_crafting</property>
+                        <property name="permission">none</property>
+                        <property name="shortcut">Shift+1</property>
+                        <property name="unchecked_bitmap"></property>
+                        <event name="OnMenuSelection">OnCancelCraftingMenuSelected</event>
                 </object>
-                <object class="wxMenu" expanded="1">
+                </object>
+                <object class="wxMenu" expanded="0">
                     <property name="label">Goal</property>
                     <property name="name">menu_goals</property>
                     <property name="permission">protected</property>
@@ -4010,6 +4024,83 @@
                                             <property name="window_name"></property>
                                             <property name="window_style"></property>
                                             <event name="OnRadioButton">OnSaveChosen</event>
+                                        </object>
+                                    </object>
+                                </object>
+                            </object>
+                            <object class="sizeritem" expanded="1">
+                                <property name="border">5</property>
+                                <property name="flag">wxEXPAND</property>
+                                <property name="proportion">1</property>
+                                <object class="wxBoxSizer" expanded="1">
+                                    <property name="minimum_size"></property>
+                                    <property name="name">bSizerCancelCrafting</property>
+                                    <property name="orient">wxVERTICAL</property>
+                                    <property name="permission">none</property>
+                                    <object class="sizeritem" expanded="1">
+                                        <property name="border">5</property>
+                                        <property name="flag">wxALL</property>
+                                        <property name="proportion">0</property>
+                                        <object class="wxRadioButton" expanded="1">
+                                            <property name="BottomDockable">1</property>
+                                            <property name="LeftDockable">1</property>
+                                            <property name="RightDockable">1</property>
+                                            <property name="TopDockable">1</property>
+                                            <property name="aui_layer"></property>
+                                            <property name="aui_name"></property>
+                                            <property name="aui_position"></property>
+                                            <property name="aui_row"></property>
+                                            <property name="best_size"></property>
+                                            <property name="bg"></property>
+                                            <property name="caption"></property>
+                                            <property name="caption_visible">1</property>
+                                            <property name="center_pane">0</property>
+                                            <property name="close_button">1</property>
+                                            <property name="context_help"></property>
+                                            <property name="context_menu">1</property>
+                                            <property name="default_pane">0</property>
+                                            <property name="dock">Dock</property>
+                                            <property name="dock_fixed">0</property>
+                                            <property name="docking">Left</property>
+                                            <property name="drag_accept_files">0</property>
+                                            <property name="enabled">1</property>
+                                            <property name="fg"></property>
+                                            <property name="floatable">1</property>
+                                            <property name="font"></property>
+                                            <property name="gripper">0</property>
+                                            <property name="hidden">0</property>
+                                            <property name="id">wxID_ANY</property>
+                                            <property name="label">Cancel Crafting</property>
+                                            <property name="max_size"></property>
+                                            <property name="maximize_button">0</property>
+                                            <property name="maximum_size"></property>
+                                            <property name="min_size"></property>
+                                            <property name="minimize_button">0</property>
+                                            <property name="minimum_size"></property>
+                                            <property name="moveable">1</property>
+                                            <property name="name">rbtn_cancel_crafting</property>
+                                            <property name="pane_border">1</property>
+                                            <property name="pane_position"></property>
+                                            <property name="pane_size"></property>
+                                            <property name="permission">protected</property>
+                                            <property name="pin_button">1</property>
+                                            <property name="pos"></property>
+                                            <property name="resize">Resizable</property>
+                                            <property name="show">1</property>
+                                            <property name="size"></property>
+                                            <property name="style"></property>
+                                            <property name="subclass">; ; forward_declare</property>
+                                            <property name="toolbar_pane">0</property>
+                                            <property name="tooltip">Cancels items in the players crafting queue, &#x0A;returning the ingredients to your hand</property>
+                                            <property name="validator_data_type"></property>
+                                            <property name="validator_style">wxFILTER_NONE</property>
+                                            <property name="validator_type">wxDefaultValidator</property>
+                                            <property name="validator_variable"></property>
+                                            <property name="value">0</property>
+                                            <property name="window_extra_style"></property>
+                                            <property name="window_name"></property>
+                                            <property name="window_style"></property>
+                                            <event name="OnRadioButton">OnCancelCraftingChosen</event>
                                         </object>
                                     </object>
                                 </object>

--- a/src/GUI/GUI.fbp
+++ b/src/GUI/GUI.fbp
@@ -4070,7 +4070,7 @@
                                             <property name="gripper">0</property>
                                             <property name="hidden">0</property>
                                             <property name="id">wxID_ANY</property>
-                                            <property name="label">Cancel Crafting</property>
+                                            <property name="label">Cancel</property>
                                             <property name="max_size"></property>
                                             <property name="maximize_button">0</property>
                                             <property name="maximum_size"></property>

--- a/src/GUI_Base.cpp
+++ b/src/GUI_Base.cpp
@@ -155,6 +155,10 @@ GUI_Base::GUI_Base( wxWindow* parent, wxWindowID id, const wxString& title, cons
 	shortcut_move_down = new wxMenuItem( menu_shortcuts, wxID_ANY, wxString( wxT("Move Down") ) + wxT('\t') + wxT("Alt+S"), wxEmptyString, wxITEM_NORMAL );
 	menu_shortcuts->Append( shortcut_move_down );
 
+	wxMenuItem* shortcut_cancel_crafting;
+	shortcut_cancel_crafting = new wxMenuItem( menu_shortcuts, wxID_ANY, wxString( wxT("Cancel Crafting") ) + wxT('\t') + wxT("Shift+1"), wxEmptyString, wxITEM_NORMAL );
+	menu_shortcuts->Append( shortcut_cancel_crafting );
+
 	m_menubar1->Append( menu_shortcuts, wxT("Shortcuts") );
 
 	menu_goals = new wxMenu();
@@ -615,6 +619,17 @@ GUI_Base::GUI_Base( wxWindow* parent, wxWindowID id, const wxString& title, cons
 
 	fgSizer3->Add( bSizer1411, 1, wxEXPAND, 5 );
 
+	wxBoxSizer* bSizerCancelCrafting;
+	bSizerCancelCrafting = new wxBoxSizer( wxVERTICAL );
+
+	rbtn_cancel_crafting = new wxRadioButton( type_panel, wxID_ANY, wxT("Cancel Crafting"), wxDefaultPosition, wxDefaultSize, 0 );
+	rbtn_cancel_crafting->SetToolTip( wxT("Cancels items in the players crafting queue, \nreturning the ingredients to your hand") );
+
+	bSizerCancelCrafting->Add( rbtn_cancel_crafting, 0, wxALL, 5 );
+
+
+	fgSizer3->Add( bSizerCancelCrafting, 1, wxEXPAND, 5 );
+
 
 	bSizer18->Add( fgSizer3, 1, wxEXPAND|wxLEFT|wxRIGHT, 15 );
 
@@ -1014,6 +1029,7 @@ GUI_Base::GUI_Base( wxWindow* parent, wxWindowID id, const wxString& title, cons
 	menu_shortcuts->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnDeleteMenuSelected ), this, shortcut_delete_step->GetId());
 	menu_shortcuts->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnMoveUpMenuSelected ), this, shortcut_move_up->GetId());
 	menu_shortcuts->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnMoveDownMenuSelected ), this, shortcut_move_down->GetId());
+	menu_shortcuts->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnCancelCraftingMenuSelected ), this, shortcut_cancel_crafting->GetId());
 	menu_goals->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnMenuSteelAxeClicked ), this, goal_steelaxe->GetId());
 	menu_goals->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnMenuGOTLAPClicked ), this, goal_GOTLAP->GetId());
 	menu_goals->Bind(wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler( GUI_Base::OnMenuAnyPercentClicked ), this, goal_any_percent->GetId());
@@ -1042,6 +1058,7 @@ GUI_Base::GUI_Base( wxWindow* parent, wxWindowID id, const wxString& title, cons
 	rbtn_drop->Connect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( GUI_Base::OnDropChosen ), NULL, this );
 	rbtn_launch->Connect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( GUI_Base::OnLaunchChosen ), NULL, this );
 	rbtn_save->Connect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( GUI_Base::OnSaveChosen ), NULL, this );
+	rbtn_cancel_crafting->Connect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( GUI_Base::OnCancelCraftingChosen ), NULL, this );
 	cmb_choose_template->Connect( wxEVT_COMMAND_COMBOBOX_SELECTED, wxCommandEventHandler( GUI_Base::OnTemplateChosen ), NULL, this );
 	btn_template_new->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( GUI_Base::OnNewTemplateClicked ), NULL, this );
 	btn_template_delete->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( GUI_Base::OnDeleteTemplateClicked ), NULL, this );
@@ -1091,6 +1108,7 @@ GUI_Base::~GUI_Base()
 	rbtn_drop->Disconnect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( GUI_Base::OnDropChosen ), NULL, this );
 	rbtn_launch->Disconnect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( GUI_Base::OnLaunchChosen ), NULL, this );
 	rbtn_save->Disconnect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( GUI_Base::OnSaveChosen ), NULL, this );
+	rbtn_cancel_crafting->Disconnect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( GUI_Base::OnCancelCraftingChosen ), NULL, this );
 	cmb_choose_template->Disconnect( wxEVT_COMMAND_COMBOBOX_SELECTED, wxCommandEventHandler( GUI_Base::OnTemplateChosen ), NULL, this );
 	btn_template_new->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( GUI_Base::OnNewTemplateClicked ), NULL, this );
 	btn_template_delete->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( GUI_Base::OnDeleteTemplateClicked ), NULL, this );

--- a/src/GUI_Base.cpp
+++ b/src/GUI_Base.cpp
@@ -622,7 +622,7 @@ GUI_Base::GUI_Base( wxWindow* parent, wxWindowID id, const wxString& title, cons
 	wxBoxSizer* bSizerCancelCrafting;
 	bSizerCancelCrafting = new wxBoxSizer( wxVERTICAL );
 
-	rbtn_cancel_crafting = new wxRadioButton( type_panel, wxID_ANY, wxT("Cancel Crafting"), wxDefaultPosition, wxDefaultSize, 0 );
+	rbtn_cancel_crafting = new wxRadioButton( type_panel, wxID_ANY, wxT("Cancel"), wxDefaultPosition, wxDefaultSize, 0 );
 	rbtn_cancel_crafting->SetToolTip( wxT("Cancels items in the players crafting queue, \nreturning the ingredients to your hand") );
 
 	bSizerCancelCrafting->Add( rbtn_cancel_crafting, 0, wxALL, 5 );

--- a/src/GUI_Base.h
+++ b/src/GUI_Base.h
@@ -101,6 +101,7 @@ class GUI_Base : public wxFrame
 		wxRadioButton* rbtn_drop;
 		wxRadioButton* rbtn_launch;
 		wxRadioButton* rbtn_save;
+		wxRadioButton* rbtn_cancel_crafting;
 		wxPanel* m_panel23;
 		wxCheckBox* check_furnace;
 		wxCheckBox* check_burner;
@@ -172,6 +173,7 @@ class GUI_Base : public wxFrame
 		virtual void OnDeleteMenuSelected( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnMoveUpMenuSelected( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnMoveDownMenuSelected( wxCommandEvent& event ) { event.Skip(); }
+		virtual void OnCancelCraftingMenuSelected( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnMenuSteelAxeClicked( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnMenuGOTLAPClicked( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnMenuAnyPercentClicked( wxCommandEvent& event ) { event.Skip(); }
@@ -200,6 +202,7 @@ class GUI_Base : public wxFrame
 		virtual void OnDropChosen( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnLaunchChosen( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnSaveChosen( wxCommandEvent& event ) { event.Skip(); }
+		virtual void OnCancelCraftingChosen( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnTemplateChosen( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnNewTemplateClicked( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnDeleteTemplateClicked( wxCommandEvent& event ) { event.Skip(); }

--- a/src/GenerateScript.cpp
+++ b/src/GenerateScript.cpp
@@ -148,6 +148,10 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 				craft(currentStep, amount == "All" ? "-1" : amount, item, comment);
 				break;
 
+			case e_cancel_crafting:
+				cancel_crafting(currentStep, amount == "All" ? "-1" : amount, item, comment);
+				break;
+
 			case e_tech:
 				tech(currentStep, item, comment);
 				break;
@@ -745,6 +749,14 @@ void GenerateScript::craft(string step, string amount, string item, string comme
 	item = check_item_name(item);
 
 	step_list += Step(step, "1", "\"craft\", " + amount + ", \"" + item + "\"", comment);
+	total_steps += 1;
+};
+
+void GenerateScript::cancel_crafting(string step, string amount, string item, string comment)
+{
+	item = check_item_name(item);
+
+	step_list += Step(step, "1", "\"cancel crafting\", " + amount + ", \"" + item + "\"", comment);
 	total_steps += 1;
 };
 

--- a/src/GenerateScript.h
+++ b/src/GenerateScript.h
@@ -105,6 +105,7 @@ private:
 	void walk(string step, string action, string x_cord, string y_cord, string comment);
 	void mining(string step, string x_cord, string y_cord, string duration, string building_name, string OrientationEnum, bool is_building, string comment);
 	void craft(string step, string amount, string item, string comment);
+	void cancel_crafting(string step, string amount, string item, string comment);
 	void tech(string step, string tech_to_research, string comment);
 	void speed(string step, string speed, string comment);
 	void pause(string step, string comment);

--- a/src/StepNameToEnum.h
+++ b/src/StepNameToEnum.h
@@ -26,7 +26,7 @@ static const vector<string> StepNames{
 	"None", 
 	"Stop", "Build", "Craft", "Game speed", "Pause", "Save",
 	"Recipe", "Limit", "Filter", "Rotate", "Priority", "Put", "Take", "Mine", "Launch",
-	"Walk", "Tech", "Drop", "Pick up", "Idle", "Cancel crafting"
+	"Walk", "Tech", "Drop", "Pick up", "Idle", "Cancel"
 };
 
 /// <summary>
@@ -34,6 +34,6 @@ static const vector<string> StepNames{
 /// </summary>
 static const map<string, StepType> MapStepNameToStepType = {{"Stop", e_stop}, {"Build", e_build}, {"Craft", e_craft}, {"Game speed", e_game_speed}, {"Pause", e_pause}, {"Save", e_save},
 	{"Recipe", e_recipe}, {"Limit", e_limit}, {"Filter", e_filter}, {"Rotate", e_rotate}, {"Priority", e_priority}, {"Put", e_put}, {"Take", e_take}, {"Mine", e_mine}, {"Launch", e_launch},
-	{"Walk", e_walk}, {"Tech", e_tech}, {"Drop", e_drop}, {"Pick up", e_pick_up}, {"Idle", e_idle}, {"Cancel crafting", e_cancel_crafting}};
+	{"Walk", e_walk}, {"Tech", e_tech}, {"Drop", e_drop}, {"Pick up", e_pick_up}, {"Idle", e_idle}, {"Cancel", e_cancel_crafting}};
 
 StepType ToStepType(string step);

--- a/src/StepNameToEnum.h
+++ b/src/StepNameToEnum.h
@@ -13,7 +13,7 @@ using std::vector;
 /// </summary>
 enum StepType
 {
-	e_stop = 1, e_build, e_craft, e_game_speed, e_pause, e_save, e_recipe, e_limit, e_filter, e_rotate, e_priority, e_put, e_take, e_mine, e_launch, e_walk, e_tech, e_drop, e_pick_up, e_idle
+	e_stop = 1, e_build, e_craft, e_game_speed, e_pause, e_save, e_recipe, e_limit, e_filter, e_rotate, e_priority, e_put, e_take, e_mine, e_launch, e_walk, e_tech, e_drop, e_pick_up, e_idle, e_cancel_crafting
 };
 
 /// <summary>
@@ -26,7 +26,7 @@ static const vector<string> StepNames{
 	"None", 
 	"Stop", "Build", "Craft", "Game speed", "Pause", "Save",
 	"Recipe", "Limit", "Filter", "Rotate", "Priority", "Put", "Take", "Mine", "Launch",
-	"Walk", "Tech", "Drop", "Pick up", "Idle"
+	"Walk", "Tech", "Drop", "Pick up", "Idle", "Cancel crafting"
 };
 
 /// <summary>
@@ -34,6 +34,6 @@ static const vector<string> StepNames{
 /// </summary>
 static const map<string, StepType> MapStepNameToStepType = {{"Stop", e_stop}, {"Build", e_build}, {"Craft", e_craft}, {"Game speed", e_game_speed}, {"Pause", e_pause}, {"Save", e_save},
 	{"Recipe", e_recipe}, {"Limit", e_limit}, {"Filter", e_filter}, {"Rotate", e_rotate}, {"Priority", e_priority}, {"Put", e_put}, {"Take", e_take}, {"Mine", e_mine}, {"Launch", e_launch},
-	{"Walk", e_walk}, {"Tech", e_tech}, {"Drop", e_drop}, {"Pick up", e_pick_up}, {"Idle", e_idle}};
+	{"Walk", e_walk}, {"Tech", e_tech}, {"Drop", e_drop}, {"Pick up", e_pick_up}, {"Idle", e_idle}, {"Cancel crafting", e_cancel_crafting}};
 
 StepType ToStepType(string step);

--- a/src/TypePanel.cpp
+++ b/src/TypePanel.cpp
@@ -55,6 +55,8 @@ void TypePanel::SwitchStep(STEP_TYPE::step_type type)
 			break;
 		case STEP_TYPE::Stop: parent->rbtn_stop->SetValue(true);
 			break;
+		case STEP_TYPE::Cancel_Crafting: parent->rbtn_cancel_crafting->SetValue(true);
+			break;
 		default:
 			// ERROR: You have done something wrong
 			break;
@@ -143,6 +145,9 @@ string cMain::ExtractStep()
 
 	if (rbtn_save->GetValue())
 		return struct_steps_list.save;
+
+	if (rbtn_cancel_crafting->GetValue())
+		return struct_steps_list.cancel_crafting;
 
 	return "not found";
 }
@@ -292,6 +297,12 @@ void cMain::OnSaveChosen(wxCommandEvent& event)
 	event.Skip();
 }
 
+void cMain::OnCancelCraftingChosen(wxCommandEvent& event)
+{
+	setup_paramters(parameter_choices.cancel_crafting);
+	event.Skip();
+}
+
 void cMain::OnPriorityChosen(wxCommandEvent& event)
 {
 	setup_paramters(parameter_choices.priority);
@@ -415,6 +426,13 @@ void cMain::OnCraftMenuSelected(wxCommandEvent& event)
 {
 	type_panel->SwitchStep(TypePanel::STEP_TYPE::Craft);
 	OnCraftChosen(event);
+	event.Skip();
+}
+
+void cMain::OnCancelCraftingMenuSelected(wxCommandEvent& event)
+{
+	type_panel->SwitchStep(TypePanel::STEP_TYPE::Cancel_Crafting);
+	OnCancelCraftingChosen(event);
 	event.Skip();
 }
 

--- a/src/TypePanel.h
+++ b/src/TypePanel.h
@@ -13,7 +13,7 @@ public:
 		{
 			Take, Put, Game_Speed, Craft, Walk, Mine,
 			Build, Recipe, Tech, Limit, Idle, Filter, Pause,
-			Priority, Rotate, Pick_Up, Drop, Launch, Save, Stop
+			Priority, Rotate, Pick_Up, Drop, Launch, Save, Stop, Cancel_Crafting
 		};
 	};
 

--- a/src/cMain.cpp
+++ b/src/cMain.cpp
@@ -1768,6 +1768,7 @@ GridEntry cMain::PrepareStepParametersForGrid(StepParameters* stepParameters)
 			break;
 
 		case e_craft:
+		case e_cancel_crafting:
 			gridEntry.Amount = stepParameters->Amount;
 			gridEntry.Item = stepParameters->Item;
 			break;
@@ -1953,6 +1954,7 @@ bool cMain::ValidateStep(const int& row, StepParameters& stepParameters, bool va
 		case e_stop:
 		case e_pick_up:
 		case e_idle:
+		case e_cancel_crafting:
 			return true;
 
 		case e_build:

--- a/src/cMain.h
+++ b/src/cMain.h
@@ -63,6 +63,7 @@ protected:
 	void OnTakeMenuSelected(wxCommandEvent& event);
 	void OnPutMenuSelected(wxCommandEvent& event);
 	void OnCraftMenuSelected(wxCommandEvent& event);
+	void OnCancelCraftingMenuSelected(wxCommandEvent& event);
 	void OnRecipeMenuChosen(wxCommandEvent& event);
 	void OnRotateMenuSelected(wxCommandEvent& event);
 	void OnAddMenuSelected(wxCommandEvent& event);
@@ -102,6 +103,7 @@ protected:
 	void OnTechChosen(wxCommandEvent& event);
 	void OnLaunchChosen(wxCommandEvent& event);
 	void OnSaveChosen(wxCommandEvent& event);
+	void OnCancelCraftingChosen(wxCommandEvent& event);
 	void OnPriorityChosen(wxCommandEvent& event);
 	void OnLimitChosen(wxCommandEvent& event);
 	void OnIdleChosen(wxCommandEvent& event);
@@ -181,6 +183,7 @@ private:
 		vector<bool> drop = {true, true, false, true, false, false, false, false, false, true, true, true};
 		vector<bool> pick = {false, false, true, false, false, false, false, false, false, false, false, false};
 		vector<bool> idle = {false, false, true, false, false, false, false, false, false, false, false, false};
+		vector<bool> cancel_crafting = {false, false, true, true, false, false, false, false, false, false, false, false};
 	} parameter_choices;
 
 	vector<string> row_selections;

--- a/src/utils.h
+++ b/src/utils.h
@@ -1171,7 +1171,7 @@ static const struct
 	std::string idle = "Idle";
 	std::string launch = "Launch";
 	std::string save = "Save";
-	std::string cancel_crafting = "Cancel crafting";
+	std::string cancel_crafting = "Cancel";
 
 } struct_steps_list;
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -1171,6 +1171,7 @@ static const struct
 	std::string idle = "Idle";
 	std::string launch = "Launch";
 	std::string save = "Save";
+	std::string cancel_crafting = "Cancel crafting";
 
 } struct_steps_list;
 


### PR DESCRIPTION
Added cancel crafting command to the GUI
Added cancel crafting step handler to lua

The GUI allows you to cancel crafting X amount of item Y
The Lua code scans the crafting queue for item Y

1.  If the scan finds item Y
- the amount is -1 then it cancels all
- the amount is less than or equal to crafting count, it cancels those
- the amount is more than what is being crafted, it throws a warning
2. If the scan doesn't find item Y, then it throws a warning 

This was a rather fast implementation, some adjustments might needed. I can see that the name "Cancel Crafting" is a bit long on the GUI. It wasn't clear from the issue how exactly it should be handled, when scanning for the desired craft to cancel.