### PR TITLE
Add multibuild to rotate

### DIFF
--- a/src/GenerateScript.cpp
+++ b/src/GenerateScript.cpp
@@ -141,7 +141,7 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 
 				SetBuildingAndOrientation(&steps[i]);
 
-				rotate(currentStep, x_cord, y_cord, amount, item, build_orientation, comment);
+				row_rotate(currentStep, x_cord, y_cord, amount, item, build_orientation, direction_to_build, amount_of_buildings, building_size, comment);
 				break;
 
 			case e_craft:
@@ -918,23 +918,42 @@ void GenerateScript::pick(string step, string amount, string comment)
 	total_steps += 1;
 }
 
-void GenerateScript::rotate(string step, string x_cord, string y_cord, string times, string item, string OrientationEnum, string comment)
+void GenerateScript::rotate(string step, string action, string x_cord, string y_cord, string times, string item, string OrientationEnum, string comment)
 {
 
-	check_interact_distance(step, "1", x_cord, y_cord, item, OrientationEnum);
+	check_interact_distance(step, action, x_cord, y_cord, item, OrientationEnum);
 
 	if (std::stoi(times) == 3)
 	{
-		step_list += Step(step, "1", "\"rotate\", {" + x_cord + ", " + y_cord + "}, " + "true", comment);
+		step_list += Step(step, action, "\"rotate\", {" + x_cord + ", " + y_cord + "}, " + "true", comment);
 		total_steps += 1;
 	}
 	else
 	{
-		for (int i = 0; i < std::stoi(times); i++)
-		{
-			step_list += Step(step, std::to_string(i + 1), "\"rotate\", {" + x_cord + ", " + y_cord + "}, " + "false", comment);
-			total_steps += 1;
-		}
+		step_list += Step(step, action, "\"rotate\", {" + x_cord + ", " + y_cord + "}, " + "false", comment);
+		total_steps += 1;
+	}
+}
+
+void GenerateScript::row_rotate(string step, string x_cord, string y_cord, string times, string item, string OrientationEnum, string direction, string number_of_buildings, string building_size, string comment)
+{
+	int action = 1, times_ = stoi(times);
+	if (times_ == 3)
+		rotate(step, std::to_string(action++), x_cord, y_cord, times, item, OrientationEnum, comment);
+	else
+		while(times_-- > 0)
+			rotate(step, std::to_string(action++), x_cord, y_cord, "1", item, OrientationEnum, comment);
+
+	for (int i = 1; i < std::stof(number_of_buildings); i++)
+	{
+		times_ = stoi(times);
+		find_coordinates(x_cord, y_cord, direction, building_size);
+
+		if (times_ == 3)
+			rotate(step, std::to_string(action++), x_cord, y_cord, times, item, OrientationEnum);
+		else
+			while (times_-- > 0)
+				rotate(step, std::to_string(action++), x_cord, y_cord, "1", item, OrientationEnum);
 	}
 }
 

--- a/src/GenerateScript.cpp
+++ b/src/GenerateScript.cpp
@@ -937,23 +937,38 @@ void GenerateScript::rotate(string step, string action, string x_cord, string y_
 
 void GenerateScript::row_rotate(string step, string x_cord, string y_cord, string times, string item, string OrientationEnum, string direction, string number_of_buildings, string building_size, string comment)
 {
-	int action = 1, times_ = stoi(times);
-	if (times_ == 3)
-		rotate(step, std::to_string(action++), x_cord, y_cord, times, item, OrientationEnum, comment);
-	else
-		while(times_-- > 0)
-			rotate(step, std::to_string(action++), x_cord, y_cord, "1", item, OrientationEnum, comment);
+	int action = 1; //action iterator
+	const int times_c = stoi(times); //constant rotation amount
+	int times_i = times_c; //rotation amount iterator
 
-	for (int i = 1; i < std::stof(number_of_buildings); i++)
+	if (times_i == 3)
 	{
-		times_ = stoi(times);
+		rotate(step, std::to_string(action++), x_cord, y_cord, times, item, OrientationEnum, comment);
+	}
+	else
+	{
+		while (times_i-- > 0)
+		{
+			rotate(step, std::to_string(action++), x_cord, y_cord, "1", item, OrientationEnum, comment);
+		}
+	}
+
+	for (int i = 1; i < stoi(number_of_buildings); i++)
+	{
+		times_i = times_c;
 		find_coordinates(x_cord, y_cord, direction, building_size);
 
-		if (times_ == 3)
+		if (times_i == 3)
+		{
 			rotate(step, std::to_string(action++), x_cord, y_cord, times, item, OrientationEnum);
+		}
 		else
-			while (times_-- > 0)
+		{
+			while (times_i-- > 0)
+			{
 				rotate(step, std::to_string(action++), x_cord, y_cord, "1", item, OrientationEnum);
+			}
+		}
 	}
 }
 

--- a/src/GenerateScript.h
+++ b/src/GenerateScript.h
@@ -112,9 +112,11 @@ private:
 	void launch(string step, string x_cord, string y_cord, string comment);
 	void save(string step, string nameOfSaveGame);
 	void idle(string step, string amount, string comment);
-	void rotate(string step, string x_cord, string y_cord, string times, string item, string OrientationEnum, string comment);
 	void pick(string step, string amount, string comment);
 
+	void rotate(string step, string action, string x_cord, string y_cord, string times, string item, string OrientationEnum, string comment = "");
+	void row_rotate(string step, string x_cord, string y_cord, string times, string item, string OrientationEnum, string direction, string number_of_buildings, string building_size, string comment);
+	
 	void build(string step, string action, string x_cord, string y_cord, string item, string OrientationEnum, string comment = "");
 	void row_build(string step, string x_cord, string y_cord, string item, string OrientationEnum, string direction, string number_of_buildings, string building_size, string comment);
 

--- a/src/StepParameters.cpp
+++ b/src/StepParameters.cpp
@@ -76,6 +76,8 @@ string StepParameters::ToString()
 			return Step + ";" + to_string(X) + ";" + to_string(Y) + ";" + Amount + ";" + ";" + Orientation + ";" + Direction + ";" + to_string(Size) + ";" + to_string(Buildings) + ";" + Comment + ";";
 
 		case e_rotate:
+			return Step + ";" + to_string(X) + ";" + to_string(Y) + ";" + Amount + ";" + Item + ";" + ";" + Direction + ";" + to_string(Size) + ";" + to_string(Buildings) + ";" + Comment + ";";
+
 		case e_mine:
 			return Step + ";" + to_string(X) + ";" + to_string(Y) + ";" + Amount + ";" + Item + ";" + ";" + ";" + ";" + ";" + Comment + ";";
 

--- a/src/cMain.cpp
+++ b/src/cMain.cpp
@@ -1540,6 +1540,10 @@ void cMain::UpdateParameters(GridEntry* gridEntry, wxCommandEvent& event)
 			spin_amount->SetValue(gridEntry->Amount);
 			txt_comment->SetValue(gridEntry->Comment);
 
+			cmb_direction_to_build->SetValue(gridEntry->DirectionToBuild);
+			spin_building_size->SetValue(gridEntry->BuildingSize);
+			spin_building_amount->SetValue(gridEntry->AmountOfBuildings);
+
 			return;
 		case e_priority:
 			OnPriorityMenuSelected(event);
@@ -1855,6 +1859,9 @@ GridEntry cMain::PrepareStepParametersForGrid(StepParameters* stepParameters)
 			gridEntry.Y = std::to_string(stepParameters->Y);
 			gridEntry.Amount = stepParameters->Amount;
 			gridEntry.Item = FindBuildingName(stepParameters->BuildingIndex);
+			gridEntry.DirectionToBuild = stepParameters->Direction;
+			gridEntry.BuildingSize = std::to_string(stepParameters->Size);
+			gridEntry.AmountOfBuildings = std::to_string(stepParameters->Buildings);
 			stepParameters->Item = gridEntry.Item;
 			break;
 

--- a/src/cMain.h
+++ b/src/cMain.h
@@ -167,7 +167,7 @@ private:
 		// x-cord, y-cord, amount, item, from/to, tech, input, output, building orientation, direction to build, building size, amount of buildings
 		vector<bool> game_speed = {false, false, true, false, false, false, false, false, false, false, false, false};
 		vector<bool> mining = {true, true, true, false, false, false, false, false, false, false, false, false};
-		vector<bool> rotate = {true, true, true, false, false, false, false, false, false, false, false, false};
+		vector<bool> rotate = {true, true, true, false, false, false, false, false, false, true, true, true};
 		vector<bool> craft = {false, false, true, true, false, false, false, false, false, false, false, false};
 		vector<bool> walk = {true, true, false, false, false, false, false, false, false, false, false, false};
 		vector<bool> build = {true, true, false, true, false, false, false, false, true, true, true, true};


### PR DESCRIPTION
Adds multibuild to rotate

Which in itself is useful, 
But also fixes a problem where if multibuild was entered into the editor. 
It could block the user from adding rotate tasks as the generator would still scan for buildings in the other locations.

It retains the idea that a rotate 5 task would create 5 rotate steps, except rotate 3 makes a counter rotate. 