### PR TITLE
Refactor: Parameter choice

### DIFF
--- a/src/Factorio-TAS-Generator.vcxproj
+++ b/src/Factorio-TAS-Generator.vcxproj
@@ -186,6 +186,7 @@
     <ClInclude Include="GenerateScript.h" />
     <ClInclude Include="GUI_Base.h" />
     <ClInclude Include="nlohmann\json.hpp" />
+    <ClInclude Include="ParameterChoices.h" />
     <ClInclude Include="SearchUtil.h" />
     <ClInclude Include="SearchUtilities.h" />
     <ClInclude Include="ShortcutChanger.h" />

--- a/src/ParameterChoices.h
+++ b/src/ParameterChoices.h
@@ -1,0 +1,65 @@
+#pragma once
+
+/* Enumarates bit vectors for specifing fields in the <Step detail> panel */ 
+enum choice_bit_vector
+{
+	x_coordinate = 1 << 0,
+	y_coordinate = 1 << 1,
+	amount = 1 << 2,
+	item = 1 << 3,
+	from_to = 1 << 4,
+	input = 1 << 5,
+	output = 1 << 6,
+	building_orientation = 1 << 7,
+	direction_to_build = 1 << 8,
+	building_size = 1 << 9,
+	amount_of_buildings = 1 << 10,
+	comment = 1 << 11,
+};
+
+/* Internal variables for parameter choices */
+namespace parameter_choice_internal
+{
+	/* Common bit vector combinations */
+	const int point = x_coordinate + y_coordinate,
+	priority_io = input + output,
+	multi_build = direction_to_build + building_size + amount_of_buildings,
+	container = amount + item + from_to,
+	building = point + multi_build + comment;
+}
+
+using namespace parameter_choice_internal;
+
+const struct parameter_choices_struct
+{
+	//game interactions
+	const int Pause = comment,
+	stop = comment,
+	save = comment,
+	game_speed = amount | comment;
+
+	//game state interactions
+	const int craft = amount | item | comment,
+	tech = item | comment,
+	cancel_crafting = amount | item | comment;
+
+	//player state interactions
+	const int walk = point | comment,
+	pick = amount | comment,
+	idle = amount | comment,
+	mining = point | amount | comment;
+
+	//building interactions
+	const int build = building | item,
+	take = building | container,
+	put = building | container,
+	rotate = building | amount,
+	limit = building | amount,
+	priority = building | priority_io,
+	recipe = building | amount | item,
+	filter = building | amount | item,
+	launch = point | comment;
+
+	//misc
+	const int drop = point | item | comment;
+} parameter_choices;

--- a/src/TypePanel.cpp
+++ b/src/TypePanel.cpp
@@ -2,6 +2,7 @@
 
 #include "cMain.h"
 #include "utils.h"
+#include "ParameterChoices.h"
 
 using std::string;
 
@@ -64,19 +65,20 @@ void TypePanel::SwitchStep(STEP_TYPE::step_type type)
 }
 
 #pragma region cMain
-void cMain::setup_paramters(std::vector<bool> parameters)
+void cMain::setup_paramters(const int parameters)
 {
-	spin_x->Enable(parameters[0]);
-	spin_y->Enable(parameters[1]);
-	spin_amount->Enable(parameters[2]);
-	cmb_item->Enable(parameters[3]);
-	cmb_from_into->Enable(parameters[4]);
-	radio_input->Enable(parameters[6]);
-	radio_output->Enable(parameters[7]);
-	cmb_building_orientation->Enable(parameters[8]);
-	cmb_direction_to_build->Enable(parameters[9]);
-	spin_building_size->Enable(parameters[11]);
-	spin_building_amount->Enable(parameters[10]);
+	using enum choice_bit_vector;
+	spin_x->Enable(parameters & x_coordinate);
+	spin_y->Enable(parameters & y_coordinate);
+	spin_amount->Enable(parameters & amount);
+	cmb_item->Enable(parameters & item);
+	cmb_from_into->Enable(parameters & from_to);
+	radio_input->Enable((bool)(input == (parameters & input)));
+	radio_output->Enable((bool)(output == (parameters & output)));
+	cmb_building_orientation->Enable(parameters & building_orientation);
+	cmb_direction_to_build->Enable(parameters & direction_to_build);
+	spin_building_size->Enable(parameters & building_size);
+	spin_building_amount->Enable(parameters & amount_of_buildings);
 }
 
 // Finds the current radio button that is choosen, 

--- a/src/cMain.h
+++ b/src/cMain.h
@@ -28,6 +28,7 @@
 #include "DialogProgressBar.h"
 #include "StepNameToEnum.h"
 #include "utils.h"
+#include "ParameterChoices.h"
 
 #include "../icon.xpm"
 
@@ -162,32 +163,6 @@ private:
 	bool auto_close_save = true;
 	bool auto_close_save_as = false;
 
-	const struct parameter_choices_struct
-	{
-		// x-cord, y-cord, amount, item, from/to, tech, input, output, building orientation, direction to build, building size, amount of buildings
-		vector<bool> game_speed = {false, false, true, false, false, false, false, false, false, false, false, false};
-		vector<bool> mining = {true, true, true, false, false, false, false, false, false, false, false, false};
-		vector<bool> rotate = {true, true, true, false, false, false, false, false, false, true, true, true};
-		vector<bool> craft = {false, false, true, true, false, false, false, false, false, false, false, false};
-		vector<bool> walk = {true, true, false, false, false, false, false, false, false, false, false, false};
-		vector<bool> build = {true, true, false, true, false, false, false, false, true, true, true, true};
-		vector<bool> take = {true, true, true, true, true, false, false, false, false, true, true, true};
-		vector<bool> put = {true, true, true, true, true, false, false, false, false, true, true, true};
-		vector<bool> filter = {true, true, true, true, false, false, false, false, false, true, true, true};
-		vector<bool> recipe = {true, true, true, true, false, false, false, false, false, true, true, true};
-		vector<bool> tech = {false, false, false, true, false, false, false, false, false, false, false, false};
-		vector<bool> launch = {true, true, false, false, false, false, false, false, false, false, false, false};
-		vector<bool> save = {false, false, false, false, false, false, false, false, false, false, false, false};
-		vector<bool> priority = {true, true, false, false, false, false, true, true, false, true, true, true};
-		vector<bool> limit = {true, true, true, false, false, false, false, false, false, true, true, true};
-		vector<bool> Pause = {false, false, false, false, false, false, false, false, false, false, false, false};
-		vector<bool> stop = {false, false, false, false, false, false, false, false, false, false, false, false};
-		vector<bool> drop = {true, true, false, true, false, false, false, false, false, false, false, false};
-		vector<bool> pick = {false, false, true, false, false, false, false, false, false, false, false, false};
-		vector<bool> idle = {false, false, true, false, false, false, false, false, false, false, false, false};
-		vector<bool> cancel_crafting = {false, false, true, true, false, false, false, false, false, false, false, false};
-	} parameter_choices;
-
 	vector<string> row_selections;
 
 	string not_relevant = "";
@@ -222,7 +197,7 @@ private:
 	void UpdateMapWithNewSteps(wxGrid* grid, wxComboBox* cmb, map<string, vector<StepParameters>>& map);
 	void UpdateTemplateGrid(wxGrid* grid, vector<StepParameters>& steps);
 
-	void setup_paramters(std::vector<bool> parameters);
+	void setup_paramters(const int parameters);
 
 	void UpdateParameters(GridEntry* gridEntry, wxCommandEvent& event);
 


### PR DESCRIPTION
This is a refactor and any functional changes are unintended.

The main objective was to
1. getting a more simple way to specify parameters types
2. going away from using unnamed indexes to specify parameter enabling

It is heavy on bit-wise operations [  &, |, <<  ], the most confusing of them is 1<<N
```
1 << 0 == 0001
1 << 1 == 0010
1 << 2 == 0100
```
I have also used chained variable constructors, which helps IntelliSense adding a comment to each of the variables:
```
        //game interactions
	const int Pause = comment,
	stop = comment,
	save = comment,
	game_speed = amount | comment;
```
![image](https://user-images.githubusercontent.com/18309265/223375490-77966ee4-0128-462f-bbc7-33cd106fbabb.png)

My favorite part happens in the internal part, where common patterns are specified.