### PR TITLE
Improvement to change Command type

### DIFF
--- a/src/TypePanel.cpp
+++ b/src/TypePanel.cpp
@@ -151,6 +151,34 @@ string cMain::ExtractStep()
 
 	return "not found";
 }
+
+void cMain::UpdateCmbItem(wxArrayString* new_list)
+{
+	if (new_list != current.cmb_item)
+	{
+		current.cmb_item = new_list;
+		cmb_item->Clear();
+		cmb_item->Append(*new_list);
+		cmb_item->SetValue(*new_list->begin());
+		cmb_item->AutoComplete(*new_list);
+	}
+}
+void cMain::UpdateLabelItem(const wxString* new_text)
+{
+	if (new_text != current.label_item)
+	{
+		current.label_item = new_text;
+		label_item->SetLabelText(*new_text);
+	}
+}
+void cMain::UpdateLabelFromInto(const wxString* new_text)
+{
+	if (new_text != current.label_from_into)
+	{
+		current.label_from_into = new_text;
+		label_from_into->SetLabelText(*new_text);
+	}
+}
 #pragma endregion
 
 #pragma region cMain eventhandlers
@@ -158,15 +186,8 @@ void cMain::OnBuildChosen(wxCommandEvent& event)
 {
 	setup_paramters(parameter_choices.build);
 
-	cmb_item->Clear();
-	for (auto it = all_buildings.begin(); it < all_buildings.end(); it++)
-	{
-		cmb_item->Append(*it);
-	}
-	cmb_item->SetValue(*all_buildings.begin());
-	cmb_item->AutoComplete(building_choices);
-
-	label_item->SetLabelText(TypePanel::item);
+	UpdateCmbItem(&building_choices);
+	UpdateLabelItem(&TypePanel::item);
 
 	event.Skip();
 }
@@ -175,18 +196,11 @@ void cMain::OnTakeChosen(wxCommandEvent& event)
 {
 	setup_paramters(parameter_choices.take);
 
-	cmb_item->Clear();
-	for (auto it = all_items.begin(); it < all_items.end(); it++)
-	{
-		cmb_item->Append(*it);
-	}
-	cmb_item->SetValue(*all_items.begin());
-	cmb_item->AutoComplete(item_choices);
+	UpdateCmbItem(&item_choices);
+	UpdateLabelItem(&TypePanel::item);
+	UpdateLabelFromInto(&TypePanel::from);
 
 	cmb_from_into->SetValue(TypePanel::output); // set default to output on take step
-
-	label_item->SetLabelText(TypePanel::item);
-	label_from_into->SetLabelText(TypePanel::from);
 
 	event.Skip();
 }
@@ -195,18 +209,11 @@ void cMain::OnPutChosen(wxCommandEvent& event)
 {
 	setup_paramters(parameter_choices.put);
 
-	cmb_item->Clear();
-	for (auto it = all_items.begin(); it < all_items.end(); it++)
-	{
-		cmb_item->Append(*it);
-	}
-	cmb_item->SetValue(*all_items.begin());
-	cmb_item->AutoComplete(item_choices);
+	UpdateCmbItem(&item_choices);
+	UpdateLabelItem(&TypePanel::item);
+	UpdateLabelFromInto(&TypePanel::from);
 
 	cmb_from_into->SetValue(TypePanel::input); // set default to input on put step
-
-	label_item->SetLabelText(TypePanel::item);
-	label_from_into->SetLabelText(TypePanel::into);
 
 	event.Skip();
 }
@@ -215,15 +222,8 @@ void cMain::OnCraftChosen(wxCommandEvent& event)
 {
 	setup_paramters(parameter_choices.craft);
 
-	cmb_item->Clear();
-	for (auto it = handcrafted_list.begin(); it < handcrafted_list.end(); it++)
-	{
-		cmb_item->Append(*it);
-	}
-	cmb_item->SetValue(*handcrafted_list.begin());
-	cmb_item->AutoComplete(handcrafted_choices);
-
-	label_item->SetLabelText(TypePanel::item);
+	UpdateCmbItem(&handcrafted_choices);
+	UpdateLabelItem(&TypePanel::item);
 
 	event.Skip();
 }
@@ -238,15 +238,8 @@ void cMain::OnfilterChosen(wxCommandEvent& event)
 {
 	setup_paramters(parameter_choices.filter);
 
-	cmb_item->Clear();
-	for (auto it = all_items.begin(); it < all_items.end(); it++)
-	{
-		cmb_item->Append(*it);
-	}
-	cmb_item->SetValue(*all_items.begin());
-	cmb_item->AutoComplete(item_choices);
-
-	label_item->SetLabelText(TypePanel::item);
+	UpdateCmbItem(&handcrafted_choices);
+	UpdateLabelItem(&TypePanel::item);
 
 	event.Skip();
 }
@@ -255,15 +248,8 @@ void cMain::OnRecipeChosen(wxCommandEvent& event)
 {
 	setup_paramters(parameter_choices.recipe);
 
-	cmb_item->Clear();
-	for (auto it = all_recipes.begin(); it < all_recipes.end(); it++)
-	{
-		cmb_item->Append(*it);
-	}
-	cmb_item->SetValue(*all_recipes.begin());
-	cmb_item->AutoComplete(recipe_choices);
-
-	label_item->SetLabelText(TypePanel::recipe);
+	UpdateCmbItem(&recipe_choices);
+	UpdateLabelItem(&TypePanel::recipe);
 
 	event.Skip();
 }
@@ -272,15 +258,8 @@ void cMain::OnTechChosen(wxCommandEvent& event)
 {
 	setup_paramters(parameter_choices.tech);
 
-	cmb_item->Clear();
-	for (auto it = tech_list.begin(); it < tech_list.end(); it++)
-	{
-		cmb_item->Append(*it);
-	}
-	cmb_item->SetValue(*tech_list.begin());
-	cmb_item->AutoComplete(tech_choices);
-
-	label_item->SetLabelText(TypePanel::tech);
+	UpdateCmbItem(&tech_choices);
+	UpdateLabelItem(&TypePanel::tech);
 
 	event.Skip();
 }
@@ -300,6 +279,10 @@ void cMain::OnSaveChosen(wxCommandEvent& event)
 void cMain::OnCancelCraftingChosen(wxCommandEvent& event)
 {
 	setup_paramters(parameter_choices.cancel_crafting);
+
+	UpdateCmbItem(&handcrafted_choices);
+	UpdateLabelItem(&TypePanel::item);
+
 	event.Skip();
 }
 
@@ -331,15 +314,8 @@ void cMain::OnDropChosen(wxCommandEvent& event)
 {
 	setup_paramters(parameter_choices.drop);
 
-	cmb_item->Clear();
-	for (auto it = all_items.begin(); it < all_items.end(); it++)
-	{
-		cmb_item->Append(*it);
-	}
-	cmb_item->SetValue(*all_items.begin());
-	cmb_item->AutoComplete(item_choices);
-
-	label_item->SetLabelText(TypePanel::item);
+	UpdateCmbItem(&item_choices);
+	UpdateLabelItem(&TypePanel::item);
 
 	event.Skip();
 }

--- a/src/TypePanel.cpp
+++ b/src/TypePanel.cpp
@@ -211,7 +211,7 @@ void cMain::OnPutChosen(wxCommandEvent& event)
 
 	UpdateCmbItem(&item_choices);
 	UpdateLabelItem(&TypePanel::item);
-	UpdateLabelFromInto(&TypePanel::from);
+	UpdateLabelFromInto(&TypePanel::into);
 
 	cmb_from_into->SetValue(TypePanel::input); // set default to input on put step
 
@@ -238,7 +238,7 @@ void cMain::OnfilterChosen(wxCommandEvent& event)
 {
 	setup_paramters(parameter_choices.filter);
 
-	UpdateCmbItem(&handcrafted_choices);
+	UpdateCmbItem(&item_choices);
 	UpdateLabelItem(&TypePanel::item);
 
 	event.Skip();

--- a/src/cMain.h
+++ b/src/cMain.h
@@ -266,4 +266,16 @@ private:
 	vector<string> all_recipes;
 	vector<StepParameters> StepGridData;
 	vector<Building> BuildingsSnapShot;
+
+	// holds the current state of some gui elements
+	struct
+	{
+		wxArrayString* cmb_item;
+		const wxString* label_item;
+		const wxString* label_from_into;
+	}current; 
+
+	void UpdateCmbItem(wxArrayString* new_list);
+	void UpdateLabelItem(const wxString* new_text);
+	void UpdateLabelFromInto(const wxString* new_text);
 };


### PR DESCRIPTION
**Added** struct that holds **pointers** to the current version of underlaying gui elements.
**Added** methods to handle **update** of gui elements
**Changed** change task to use the new methods

This fixes #178 by only **updating** the item list, if it is **different**. There are a bunch of list of items floating around, and they have some overlap which isn't accounted for. For instance, switching from Craft:gear to set Recipe will still reset to accumulator.

Performance is **massively** improve by both only updating the element if is different and by using wxComboBox.Append with a wxArrayString instead of individual wxString's.