### PR TITLE
Retain last value of cmb_item when changing list

### DIFF
--- a/src/Functions.cpp
+++ b/src/Functions.cpp
@@ -254,3 +254,12 @@ vector<wxString> Split(const string& s, char delim)
 	if (result.empty()) result.push_back(s);
 	return result;
 }
+
+bool ListContains(wxArrayString* list, wxString str)
+{
+	for (int i = 0; i < list->GetCount(); i++)
+	{
+		if (list->Item(i) == str) return true;
+	}
+	return false;
+}

--- a/src/Functions.h
+++ b/src/Functions.h
@@ -38,3 +38,4 @@ void PopulateGrid(wxGrid* grid, int row, GridEntry* gridEntry);
 
 bool StringContainsAny(const wxString& str, const string& chars);
 vector<wxString> Split(const string& s, char delim);
+bool ListContains(wxArrayString* list, wxString str);

--- a/src/TypePanel.cpp
+++ b/src/TypePanel.cpp
@@ -158,10 +158,17 @@ void cMain::UpdateCmbItem(wxArrayString* new_list)
 {
 	if (new_list != current.cmb_item)
 	{
+		if (!current.map_last_item.contains(new_list)) // if map_last_item does not contain new_list, add it
+			current.map_last_item.insert(std::pair(new_list, *new_list->begin()));
+		const wxString current_value = cmb_item->GetValue();
+		// either the new list contains the current value or default to the new list's last value
+		wxString last = ListContains(new_list, current_value) ? current_value : current.map_last_item[new_list];
+		current.map_last_item[current.cmb_item] = current_value; // update last item of the list we leave
+
 		current.cmb_item = new_list;
 		cmb_item->Clear();
 		cmb_item->Append(*new_list);
-		cmb_item->SetValue(*new_list->begin());
+		cmb_item->SetValue(last);
 		cmb_item->AutoComplete(*new_list);
 	}
 }

--- a/src/cMain.h
+++ b/src/cMain.h
@@ -250,6 +250,7 @@ private:
 		wxArrayString* cmb_item;
 		const wxString* label_item;
 		const wxString* label_from_into;
+		map<wxArrayString*, wxString> map_last_item;
 	}current; 
 
 	void UpdateCmbItem(wxArrayString* new_list);


### PR DESCRIPTION
#192 Completed
Added map of last items
Added function that scans for wxArrayString contains item 
Changed UpdateCmbItem to either retain its value or update to the new list's last item