### PR TITLE
Select last selected rows on load

### DIFF
--- a/src/OpenTas.cpp
+++ b/src/OpenTas.cpp
@@ -58,6 +58,17 @@ open_file_return_data* OpenTas::Open(DialogProgressBar* dialog_progress_bar, std
 		return_data.success = true;
 	}
 
+	if (update_segment(file))
+	{
+		return_data.selected_rows = wxGridBlockCoordsVector();
+		for (int i = 1; i < segments.size(); i += 2)
+		{
+			return_data.selected_rows.push_back(
+				wxGridBlockCoords(stoi(segments[i]), 0, stoi(segments[i + 1]), 9)
+			);
+		}
+	}
+
 	return &return_data;
 }
 

--- a/src/OpenTas.h
+++ b/src/OpenTas.h
@@ -30,6 +30,8 @@ struct open_file_return_data
 	string save_file_location;
 	string generate_code_folder_location;
 
+	wxGridBlockCoordsVector selected_rows;
+
 	bool auto_close_generate_script = false;
 	bool auto_close_open = false;
 	bool auto_close_save = false;

--- a/src/SaveTas.cpp
+++ b/src/SaveTas.cpp
@@ -13,6 +13,7 @@ bool SaveTas::Save(
 	string folder_location,
 	string folder_location_generate,
 	string goal,
+	wxGridBlockCoordsVector selected_rows,
 	bool set_last_location)
 {
 	int total_lines = steps.size();
@@ -93,7 +94,12 @@ bool SaveTas::Save(
 	myfile << auto_put_furnace_text << ";" << bool_to_string(auto_list[4]) << std::endl;
 	myfile << auto_put_burner_text << ";" << bool_to_string(auto_list[5]) << std::endl;
 	myfile << auto_put_lab_text << ";" << bool_to_string(auto_list[6]) << std::endl;
-	myfile << auto_put_recipe_text << ";" << bool_to_string(auto_list[7]);
+	myfile << auto_put_recipe_text << ";" << bool_to_string(auto_list[7]) << std::endl;
+
+	string s_selected_rows = "";
+	for (auto p : selected_rows) 
+		s_selected_rows += to_string(p.GetTopRow()) + ";" + to_string(p.GetBottomRow()) + ";";
+	myfile << "selected rows;" << s_selected_rows;
 
 	myfile.close();
 

--- a/src/SaveTas.h
+++ b/src/SaveTas.h
@@ -29,6 +29,7 @@ public:
 		string folder_location,
 		string folder_location_generate,
 		string goal,
+		wxGridBlockCoordsVector selected_rows,
 		bool set_last_location = true
 	);
 

--- a/src/cMain.cpp
+++ b/src/cMain.cpp
@@ -1295,6 +1295,27 @@ void cMain::Open(std::ifstream * file)
 		dialog_progress_bar->set_button_enable(true);
 	}
 
+	if (!result->selected_rows.empty())
+	{
+		int row_count = grid_steps->GetNumberRows();
+		int first_row_index = result->selected_rows[0].GetTopRow();
+		if (row_count > 0 && first_row_index < row_count)
+		{
+			wxGridEvent mock_event = wxGridEvent(0, wxEVT_GRID_CELL_LEFT_DCLICK, 0, first_row_index);
+			OnStepsGridDoubleLeftClick(mock_event); // load first row into detail panel
+			grid_steps->GoToCell(first_row_index, 0); // move the grid to first selected row
+
+			for (auto block : result->selected_rows)
+			{
+				if (block.GetTopRow() < row_count && block.GetBottomRow() < row_count) // verify the selected rows are still in the grid
+				{
+					grid_steps->SelectBlock(block.GetTopLeft(), block.GetBottomRight(), true); // select each block
+				}
+			}
+			
+		}
+	}
+
 	no_changes = true;
 }
 
@@ -1752,6 +1773,7 @@ bool cMain::Save(string filename, bool save_as, bool set_last_location)
 		filename,
 		generate_code_folder_location,
 		goal,
+		grid_steps->GetSelectedRowBlocks(),
 		set_last_location);
 }
 

--- a/src/cMain.cpp
+++ b/src/cMain.cpp
@@ -1303,6 +1303,7 @@ void cMain::Open(std::ifstream * file)
 		{
 			wxGridEvent mock_event = wxGridEvent(0, wxEVT_GRID_CELL_LEFT_DCLICK, 0, first_row_index);
 			OnStepsGridDoubleLeftClick(mock_event); // load first row into detail panel
+			grid_steps->GoToCell(row_count-1, 0);
 			grid_steps->GoToCell(first_row_index, 0); // move the grid to first selected row
 
 			for (auto block : result->selected_rows)

--- a/src/cMain.cpp
+++ b/src/cMain.cpp
@@ -1304,7 +1304,7 @@ void cMain::Open(std::ifstream * file)
 			wxGridEvent mock_event = wxGridEvent(0, wxEVT_GRID_CELL_LEFT_DCLICK, 0, first_row_index);
 			OnStepsGridDoubleLeftClick(mock_event); // load first row into detail panel
 			grid_steps->GoToCell(row_count-1, 0);
-			grid_steps->GoToCell(first_row_index - first_row_index > 4? 3:0, 0); // move the grid to first selected row
+			grid_steps->GoToCell(first_row_index - (first_row_index > 4 ? 3 : 0), 0); // move the grid to first selected row
 
 			for (auto block : result->selected_rows)
 			{

--- a/src/cMain.cpp
+++ b/src/cMain.cpp
@@ -1304,7 +1304,7 @@ void cMain::Open(std::ifstream * file)
 			wxGridEvent mock_event = wxGridEvent(0, wxEVT_GRID_CELL_LEFT_DCLICK, 0, first_row_index);
 			OnStepsGridDoubleLeftClick(mock_event); // load first row into detail panel
 			grid_steps->GoToCell(row_count-1, 0);
-			grid_steps->GoToCell(first_row_index, 0); // move the grid to first selected row
+			grid_steps->GoToCell(first_row_index - first_row_index > 4? 3:0, 0); // move the grid to first selected row
 
 			for (auto block : result->selected_rows)
 			{


### PR DESCRIPTION
Added selected rows to the bottom of tas file

Changed load tas file to:
 Re-Select last selected rows
 Double clicks the top row of last selected rows
 Scroll top row of last selected rows

It ignores selected blocks where either the top or bottom row is outside the scope of the step grid

![image](https://user-images.githubusercontent.com/18309265/224283396-dd2df171-87fd-4f19-82dd-8614511cc8e3.png)
As seen in the image, it re-select rows in grey instead of the usual blue. That wasn't intentional, but i like the effect.
It isn't evident from the image that it also scrolls the step grid to the top row. Nor is it visible that it loads the top row into Step Details and Step Type.