### PR TITLE
Command limit uses wrong inventory

### DIFF
--- a/src/GenerateScript.cpp
+++ b/src/GenerateScript.cpp
@@ -61,9 +61,9 @@ string GenerateScript::EndSteps()
 	return step_list + last_step + return_line;
 }
 
-void GenerateScript::UnexpectedError(DialogProgressBar* dialog_progress_bar)
+void GenerateScript::UnexpectedError(DialogProgressBar* dialog_progress_bar, int i)
 {
-	wxMessageBox("Please make an issue at our repository on github with step by step of what happened.", "Unexpected error");
+	wxMessageBox("Unexpected error on step "+std::to_string(i+1)+"\nPlease make an issue at our repository on github with step by step of what happened.\nhttps://github.com/MortenTobiasNielsen/Factorio-TAS-Generator", "Unexpected error");
 	dialog_progress_bar->Close();
 }
 
@@ -173,7 +173,7 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 			case e_rotate:
 				if (steps[i].BuildingIndex == 0)
 				{
-					UnexpectedError(dialog_progress_bar);
+					UnexpectedError(dialog_progress_bar, i);
 					return;
 				}
 
@@ -205,7 +205,7 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 
 				if (from_into == "Not Found")
 				{
-					UnexpectedError(dialog_progress_bar);
+					UnexpectedError(dialog_progress_bar, i);
 					return;
 				}
 
@@ -219,7 +219,7 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 
 				if (from_into == "Not Found")
 				{
-					UnexpectedError(dialog_progress_bar);
+					UnexpectedError(dialog_progress_bar, i);
 					return;
 				}
 
@@ -248,7 +248,7 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 
 				if (from_into == "Not Found")
 				{
-					UnexpectedError(dialog_progress_bar);
+					UnexpectedError(dialog_progress_bar, i);
 					return;
 				}
 
@@ -259,7 +259,7 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 
 				if (steps[i].BuildingIndex == 0)
 				{
-					UnexpectedError(dialog_progress_bar);
+					UnexpectedError(dialog_progress_bar, i);
 					return;
 				}
 
@@ -271,7 +271,7 @@ void GenerateScript::generate(wxWindow* parent, DialogProgressBar* dialog_progre
 			case e_filter:
 				if (steps[i].BuildingIndex == 0)
 				{
-					UnexpectedError(dialog_progress_bar);
+					UnexpectedError(dialog_progress_bar, i);
 					return;
 				}
 

--- a/src/GenerateScript.h
+++ b/src/GenerateScript.h
@@ -63,7 +63,7 @@ private:
 	void reset();
 	void ClearSteps();
 	string EndSteps();
-	void UnexpectedError(DialogProgressBar* dialog_progress_bar);
+	void UnexpectedError(DialogProgressBar* dialog_progress_bar, int error_step);
 
 	void AddInfoFile(string& folder_location);
 

--- a/src/cMain.cpp
+++ b/src/cMain.cpp
@@ -1992,6 +1992,7 @@ GridEntry cMain::PrepareStepParametersForGrid(StepParameters* stepParameters)
 			break;
 
 		case e_limit:
+			stepParameters->Orientation = "Chest";
 			gridEntry.X = std::to_string(stepParameters->X);
 			gridEntry.Y = std::to_string(stepParameters->Y);
 			gridEntry.Amount = stepParameters->Amount;


### PR DESCRIPTION
Extended the warning on unexpected error while generating script, to include the index of the row that caused it.
Extended the warning on unexpected error while generating script, to include a reference to this repository
  If we want the reference to behave like a hyperlink we can investigate https://forums.wxwidgets.org/viewtopic.php?t=35990

Added a simple fix to Limit, by overriding `stepParameters->Orientation = "Chest";` in PrepareStepParametersForGrid